### PR TITLE
fix: ensure pods have k8s labels

### DIFF
--- a/infrastructure/k8s/vault-overrides.yaml
+++ b/infrastructure/k8s/vault-overrides.yaml
@@ -85,6 +85,8 @@ server:
             leader_ca_cert_file = "/vault/userconfig/{{ .Values.global.certSecretName }}/ca.crt"
             }
         }
+
+        service_registration "kubernetes" {}
   image:
     repository: vault # TODO: will change to the omgnetwork/vault image
     tag: 1.5.4

--- a/infrastructure/scripts/gen_overrides.sh
+++ b/infrastructure/scripts/gen_overrides.sh
@@ -152,6 +152,8 @@ storage "raft" {
     leader_ca_cert_file = "/vault/userconfig/{{ .Values.global.certSecretName }}/ca.crt"
     }
 }
+
+service_registration "kubernetes" {}
 EOF
 
   cd k8s


### PR DESCRIPTION
This enables Kubernetes Service Registration, which means that the Vault
pods get the correct labels. Without this, the vault-active service is
broken, it can never identify the master in the Vault cluster.

https://www.vaultproject.io/docs/configuration/service-registration/kubernetes