### PR TITLE
fix(circleci): fix docker network race condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
           name: Infra standup
           working_directory: /home/circleci/project/docker
           command: docker-compose up ganache truffle
+          background: true
+      # prevent docker network creation race condition
+      - run: sleep 5 
       - run:
           name: Test
           working_directory: /home/circleci/project/docker


### PR DESCRIPTION
This should fix the flaky CI build. I don't think this will add very
much to the build runtime, as vault_server needs to wait on truffle
anyway.

Note the build always succeeds at the moment, even when tests fail.